### PR TITLE
v8.3.1 - 2021-11-06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Intercept Redirect
 
+## v8.3.1 - 2021-11-06
+- Fix duplicate entry: 2nd `*://www.google.com/imgres` should have been `*://www.google.se/imgres`
+- [Tests] Start using `addons-linter`
+
 ## v8.3.0 - 2021-11-06
 - Add `www.google.se`
 - Only redirect `sorry/index` from `google.com`

--- a/package.json
+++ b/package.json
@@ -1,17 +1,19 @@
 {
   "name": "@bjornstar/intercept-redirect",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Skip tracking redirects that serve no purpose other than to waste your valuable time.",
   "main": "webextension/index.js",
   "devDependencies": {
+    "addons-linter": "^4.0.0",
     "eslint": "^8.2.0",
     "mocha": "^9.1.3"
   },
   "scripts": {
+    "addons-linter": "addons-linter webextension",
     "build": "./build.sh",
     "lint": "eslint webextension test",
     "mocha": "mocha test",
-    "test": "npm run lint && npm run mocha"
+    "test": "npm run lint && npm run mocha && npm run addons-linter"
   },
   "repository": {
     "type": "git",

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -34,7 +34,7 @@
     "*://www.google.com/imgres",
     "*://www.google.com/sorry/index",
     "*://www.google.com/url",
-    "*://www.google.com/imgres",
+    "*://www.google.se/imgres",
     "*://www.google.se/url",
     "*://www.googleadservices.com/pagead/aclk",
     "*://href.li/",
@@ -56,5 +56,5 @@
     "*://workable.com/nr",
     "*://www.youtube.com/redirect"
   ],
-  "version": "8.3.0"
+  "version": "8.3.1"
 }


### PR DESCRIPTION
- Fix duplicate entry: 2nd `*://www.google.com/imgres` should have been `*://www.google.se/imgres`
- [Tests] Start using `addons-linter`
