### PR TITLE
v8.15.0 - 2025-05-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Intercept Redirect
 
+## v8.15.0 - 2025-05-25
+- Handle nested redirects (Fixes #64)
+- [manifest.json] Remove unused `google.com/sorry` permission
+- [README.md] Fix `shields.io` badge for Edge addon version
+- [devDependencies] Update `addons-linter`, `eslint`, & `mocha`
+- [tests] Ensure every permissions entry in the manifest has a test
+
 ## v8.14.0 - 2025-03-13
-- Remove support for `/sorry` from `google.come`
+- Remove support for `/sorry` from `google.com`
 - Support `u` parameter on `steampowered.com` (Fixes #62)
 - [devDependencies] Update `addons-linter`, `eslint`, & `mocha`
 - [README.md] Add Edge version badge

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Github Badge](https://github.com/bjornstar/intercept-redirect/actions/workflows/nodejs.yml/badge.svg?branch=master)](https://github.com/bjornstar/intercept-redirect/actions/workflows/nodejs.yml)
 
 [![AMO Badge](https://img.shields.io/amo/v/intercept-redirect)](https://intercept-redirect.firefox.bjornstar.com)
-[![Edge Badge](https://img.shields.io/badge/dynamic/json?label=edge%20add-on&prefix=v&query=%24.version&url=https%3A%2F%2Fmicrosoftedge.microsoft.com%2Faddons%2Fdetail%2Fintercept-redirect%2Flcepiodcdgkegeepkekedmelbcfeijni)](https://intercept-redirect.edge.bjornstar.com)
+[![Edge Badge](https://img.shields.io/badge/dynamic/json?label=edge%20add-on&prefix=v&query=%24.version&url=https%3A%2F%2Fmicrosoftedge.microsoft.com%2Faddons%2Fgetproductdetailsbycrxid%2Flcepiodcdgkegeepkekedmelbcfeijni)](https://intercept-redirect.edge.bjornstar.com)
 [![CWS Badge](https://img.shields.io/chrome-web-store/v/kdjmiebhgaleboaamnehjbamlghkoedf)](https://intercept-redirect.chrome.bjornstar.com)
 
 Skip tracking redirects that serve no purpose other than to waste your valuable time.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@bjornstar/intercept-redirect",
-  "version": "8.14.0",
+  "version": "8.15.0",
   "description": "Skip tracking redirects that serve no purpose other than to waste your valuable time.",
   "main": "webextension/index.js",
   "devDependencies": {
-    "addons-linter": "^7.8.0",
-    "eslint": "^9.22.0",
-    "mocha": "^11.1.0"
+    "addons-linter": "^7.13.0",
+    "eslint": "^9.27.0",
+    "mocha": "^11.5.0"
   },
   "scripts": {
     "addons-linter": "addons-linter webextension",

--- a/webextension/index.js
+++ b/webextension/index.js
@@ -1,10 +1,7 @@
-// URL polyfill
-const URL = typeof window === 'object' ? window.URL : require('url').URL;
-
 const matchPatternToRegex = mp => `^${mp.replace(/\./, '\\.').replace(/\*/, '.*')}`;
 
-const ensureProtocol = s => {
-  const prepend = /^.*:\/\//.test(s) ? '' : 'https://';
+const ensureProtocol = (s = '') => {
+  const prepend = (!s || /^.*:\/\//.test(s)) ? '' : 'https://';
   return `${prepend}${s}`;
 };
 
@@ -233,13 +230,11 @@ function analyzeURL(request) {
 
   const site = sites[host];
 
-  if (!site) {
-    return;
-  }
+  if (!site) return;
 
-  const redirectUrl = find(redirectExtractors[host], url);
+  const redirected = ensureProtocol(find(redirectExtractors[host], url));
 
-  return redirectUrl && { redirectUrl: ensureProtocol(redirectUrl) };
+  return redirected ? analyzeURL({ url: redirected }) || { redirectUrl: redirected } : undefined;
 }
 
 // Only runs in the browser

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -39,7 +39,6 @@
     "*://news.url.google.com/url",
     "*://plus.url.google.com/url",
     "*://www.google.com/imgres",
-    "*://www.google.com/sorry/index",
     "*://www.google.com/url",
     "*://www.google.se/imgres",
     "*://www.google.se/url",
@@ -71,5 +70,5 @@
     "*://workable.com/nr",
     "*://www.youtube.com/redirect"
   ],
-  "version": "8.14.0"
+  "version": "8.15.0"
 }


### PR DESCRIPTION
- Handle nested redirects (Fixes #64)
- [manifest.json] Remove unused `google.com/sorry` permission
- [README.md] Fix `shields.io` badge for Edge addon version
- [devDependencies] Update `addons-linter`, `eslint`, & `mocha`
- [tests] Ensure every permissions entry in the manifest has a test